### PR TITLE
added similar user group weighing

### DIFF
--- a/backend/configuration.py
+++ b/backend/configuration.py
@@ -1,0 +1,90 @@
+import os
+from dotenv import load_dotenv
+from datetime import timedelta, date
+from dateutil.relativedelta import relativedelta
+
+load_dotenv()
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+
+TTL = timedelta(hours=24)
+HARDCODED_ENDDATE = date(2025, 4, 14)
+ONE_MONTH_BACK = relativedelta(weeks=4)
+
+FEATURE_ORDER = [
+    "home",
+    "guard",
+    "center",
+    "forward",
+    "restDays",
+    "season_end",
+    "last7GameAvg",
+    "season_begin",
+    "forward_guard",
+    "guard_forward",
+    "seasonAverage",
+    "season_middle",
+    "center_forward",
+    "forward_center",
+    "opponentPointsAllowed",
+]
+
+TEAM_ABBREVIATIONS = {
+    "ATL": "Atlanta Hawks",
+    "BOS": "Boston Celtics",
+    "BKN": "Brooklyn Nets",
+    "CHA": "Charlotte Hornets",
+    "CHI": "Chicago Bulls",
+    "CLE": "Cleveland Cavaliers",
+    "DAL": "Dallas Mavericks",
+    "DEN": "Denver Nuggets",
+    "DET": "Detroit Pistons",
+    "GSW": "Golden State Warriors",
+    "HOU": "Houston Rockets",
+    "IND": "Indiana Pacers",
+    "LAC": "LA Clippers",
+    "LAL": "Los Angeles Lakers",
+    "MEM": "Memphis Grizzlies",
+    "MIA": "Miami Heat",
+    "MIL": "Milwaukee Bucks",
+    "MIN": "Minnesota Timberwolves",
+    "NOP": "New Orleans Pelicans",
+    "NYK": "New York Knicks",
+    "OKC": "Oklahoma City Thunder",
+    "ORL": "Orlando Magic",
+    "PHI": "Philadelphia 76ers",
+    "PHX": "Phoenix Suns",
+    "POR": "Portland Trail Blazers",
+    "SAC": "Sacramento Kings",
+    "SAS": "San Antonio Spurs",
+    "TOR": "Toronto Raptors",
+    "UTA": "Utah Jazz",
+    "WAS": "Washington Wizards"
+}
+
+NORMALIZE_KEYS = [
+    "seasonAverage", 
+    "last7GameAvg", 
+    "restDays", 
+    "opponentPointsAllowed"
+]
+
+MULTIPLE_SIMILAR = 5 # multiple similar teams or players
+ONE_SIMILAR = 4 # one similar team or player
+
+# first value is for team heuristic, second value is for player heuristic
+MULTIPLE_SIMILAR_PLAYER_TEAMS = (3, 1) 
+ONE_SIMILAR_PLAYER_TEAM = (2, 0.5)
+
+SAME_CITY = 1
+SAME_STATE = 0.75
+SAME_DIVISION = 0.5
+SAME_CONFERENCE = 0.25
+
+SIMILAR_PPG = 3
+SIMILAR_POSITION = 2
+
+SIMILAR_INTERACTION = (2, 3)
+NEIGHBORING_INTERACTION = (1, 1.5)

--- a/backend/modalHelpers.py
+++ b/backend/modalHelpers.py
@@ -1,11 +1,7 @@
+from configuration import HARDCODED_ENDDATE, ONE_MONTH_BACK
 from stats import getPlayerGameLog, getTeamGameLog, additionalPlayerInfo
-from fastapi import HTTPException
 import pandas as pd
-from datetime import date, datetime, timezone
-from dateutil.relativedelta import relativedelta
-
-HARDCODED_ENDDATE = date(2025, 4, 14)
-ONE_MONTH_BACK = relativedelta(weeks=4)
+from datetime import datetime, timezone
 
 def playerJson(row, id, additionalInfo):
     return {

--- a/backend/predictionDataHelpers.py
+++ b/backend/predictionDataHelpers.py
@@ -197,6 +197,6 @@ def getUserWeights(userId, userInteractions):
 
     orderedWeights = []
     for category in FEATURE_ORDER:
-        orderedWeights.append(weights[category])
+        orderedWeights.append(weights[category] * 0.5) # we only want the user weight to be half of the final weight
 
     return orderedWeights

--- a/backend/predictionDataHelpers.py
+++ b/backend/predictionDataHelpers.py
@@ -1,64 +1,8 @@
+from configuration import SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TEAM_ABBREVIATIONS, NORMALIZE_KEYS, FEATURE_ORDER
 import pandas as pd
 from stats import getFullTeamStats
 from datetime import datetime
 from supabase import create_client
-import os
-from dotenv import load_dotenv
-
-load_dotenv()
-
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-
-monthlyPeriods = {
-    "OCT": "season_begin",
-    "NOV": "season_begin",
-    "DEC": "season_middle",
-    "JAN": "season_middle",
-    "FEB": "season_middle",
-    "MAR": "season_end",
-    "APR": "season_end"
-}
-
-teamAbbreviations = {
-    "ATL": "Atlanta Hawks",
-    "BOS": "Boston Celtics",
-    "BKN": "Brooklyn Nets",
-    "CHA": "Charlotte Hornets",
-    "CHI": "Chicago Bulls",
-    "CLE": "Cleveland Cavaliers",
-    "DAL": "Dallas Mavericks",
-    "DEN": "Denver Nuggets",
-    "DET": "Detroit Pistons",
-    "GSW": "Golden State Warriors",
-    "HOU": "Houston Rockets",
-    "IND": "Indiana Pacers",
-    "LAC": "LA Clippers",
-    "LAL": "Los Angeles Lakers",
-    "MEM": "Memphis Grizzlies",
-    "MIA": "Miami Heat",
-    "MIL": "Milwaukee Bucks",
-    "MIN": "Minnesota Timberwolves",
-    "NOP": "New Orleans Pelicans",
-    "NYK": "New York Knicks",
-    "OKC": "Oklahoma City Thunder",
-    "ORL": "Orlando Magic",
-    "PHI": "Philadelphia 76ers",
-    "PHX": "Phoenix Suns",
-    "POR": "Portland Trail Blazers",
-    "SAC": "Sacramento Kings",
-    "SAS": "San Antonio Spurs",
-    "TOR": "Toronto Raptors",
-    "UTA": "Utah Jazz",
-    "WAS": "Washington Wizards"
-}
-
-normalizeKeys = [
-    "seasonAverage", 
-    "last7GameAvg", 
-    "restDays", 
-    "opponentPointsAllowed"
-]
 
 def getOpponentPointAllowed(dict):
     teamAverages = getFullTeamStats()
@@ -80,7 +24,7 @@ def playerPositionInfo(position):
 
 def opponentOppgInfo(matchup, teamOppg):
     opponentAbbreviation = matchup[2]
-    opponentName = teamAbbreviations[opponentAbbreviation]
+    opponentName = TEAM_ABBREVIATIONS[opponentAbbreviation]
     opponentOppg = teamOppg[opponentName] # * opponent's oppg for feature
 
     return opponentOppg
@@ -142,13 +86,13 @@ def normalizeData(sb, players, means, stdDevs):
             normalizedFeature = {}
 
             # normalizing and adding weight to continuous values
-            for key in normalizeKeys:
+            for key in NORMALIZE_KEYS:
                 z = (feature[key] - means[key]) / stdDevs[key]
                 normalizedFeature[key] = z
 
             # adding weight to binary values
             for key, value in feature.items():
-                if key not in normalizeKeys:
+                if key not in NORMALIZE_KEYS:
                     normalizedFeature[key] = value
 
             normalizedFeatures.append(normalizedFeature)
@@ -173,21 +117,21 @@ def getMeansAndStdDevs(sb):
     df = convertDataToDataFrame(resp)
 
     # getting means and std deviations for each feature that we're normalizing
-    means = df[normalizeKeys].mean()
-    stdDevs  = df[normalizeKeys].std(ddof=0)
+    means = df[NORMALIZE_KEYS].mean()
+    stdDevs  = df[NORMALIZE_KEYS].std(ddof=0)
     return [resp, means, stdDevs]
 
 def normalizeInput(feature, means, stdDevs):
     normalizedFeature = {}
 
     # normalizing and adding weight to continuous values
-    for key in normalizeKeys:
+    for key in NORMALIZE_KEYS:
         z = (feature[key] - means[key]) / stdDevs[key]
         normalizedFeature[key] = z
 
     # adding weight to binary values
     for key, value in feature.items():
-        if key not in normalizeKeys:
+        if key not in NORMALIZE_KEYS:
             normalizedFeature[key] = value
     
     return normalizedFeature
@@ -221,7 +165,7 @@ def getUserInteractions(sb, averages, user_id):
         "point": data["point_count"] / averages["point"]
     }
 
-def getUserWeights(userId, sb, userInteractions, order):
+def getUserWeights(userId, userInteractions):
     weights = {
         "seasonAverage": 3.00,
         "last7GameAvg": 4.00,
@@ -252,7 +196,7 @@ def getUserWeights(userId, sb, userInteractions, order):
                 weights[category] *= userInteractions[interaction]
 
     orderedWeights = []
-    for category in order:
+    for category in FEATURE_ORDER:
         orderedWeights.append(weights[category])
 
     return orderedWeights

--- a/backend/predictionModel.py
+++ b/backend/predictionModel.py
@@ -1,8 +1,6 @@
+from configuration import SUPABASE_URL, SUPABASE_ANON_KEY
 import numpy as np
 import pandas as pd
-from collections import Counter
-import os
-from dotenv import load_dotenv
 from supabase import create_client
 
 class KNN:
@@ -41,10 +39,6 @@ def trainModel(data, k):
 
 # * Uncomment this to test the model
 # def main():
-#     load_dotenv()
-#     SUPABASE_URL    = os.getenv("SUPABASE_URL")
-#     SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY")
-
 #     sb = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
 #     resp = sb.from_("normalized_data")\
 #         .select("features, targets")\

--- a/backend/similarUserWeights.py
+++ b/backend/similarUserWeights.py
@@ -1,97 +1,78 @@
 from configuration import SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY, MULTIPLE_SIMILAR, ONE_SIMILAR, MULTIPLE_SIMILAR_PLAYER_TEAMS, ONE_SIMILAR_PLAYER_TEAM, SAME_CITY, SAME_STATE, SAME_DIVISION, SAME_CONFERENCE, SIMILAR_PPG, SIMILAR_POSITION, SIMILAR_INTERACTION, NEIGHBORING_INTERACTION
-from predictionDataHelpers import getInteractionAverages, getUserInteractions, getUserWeights
+from predictionDataHelpers import getUserWeights, getUserInteractions
 from stats import additionalPlayerInfo, getPlayerSeasonStats
 from modalHelpers import playerJson
 from supabase import create_client
 import numpy as np
 
-# get all the favorites for a given user
-def getActiveUserFavorites(user_id):
-    sb = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
-    resp = sb.from_("favorites")\
-        .select("target_id, target_type")\
-        .eq("user_id", user_id)\
-        .execute()
-    favorites = resp.data
+# combining all the functions that I have to determine the values for weights based on similar user groups
+def getSimilarUserWeights(activeUser, interactionAverages):
+    sb = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY) # we need the service role key to override RLS
+    users = getUsers()
+    favoriteCountAverage = getFavoriteCountAverage(len(users))
+    
+    # getting necessary variables for the user that is currently logged in
+    activePlayers, activeTeams, activeCities, activeStates, activeDivisions, activeConferences, activePositions, activePlayerTeams, activePoints, activeFavoriteRatio, activeUserInteractions, activeUserTotalInteractionsRatio = getUserValues(activeUser, sb, interactionAverages, favoriteCountAverage)
 
-    players = set()
-    teams = set()
-    for favorite in favorites:
-        if favorite["target_type"] == "player":
-            players.add(favorite["target_id"])
-        else:
-            teams.add(favorite["target_id"])
+    teamHeuristics = []
+    playerHeuristics = []
+    usageHeuristics = []
+    interactionHeuristics = []
+    for currUser in users:
+        if currUser == activeUser:
+            continue
         
-    return [players, teams]
+        # getting necessary variables for all users that are not the currently logged in user
+        currPlayers, currTeams, currCities, currStates, currDivisions, currConferences, currPositions, currPlayerTeams, currPoints, currFavoriteRatio, currUserInteractions, currUserTotalInteractionsRatio = getUserValues(currUser, sb, interactionAverages, favoriteCountAverage)
 
-# get the average favorite count across all users
-def getFavoriteCountAverage(userCount):
-    sb = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
-    resp = sb.from_("favorites")\
-        .select("user_id")\
-        .execute()
+        # calculating heuristic values for each user
+        teamHeuristics.append(calculateTeamHeuristic(activeTeams, activeCities, activeStates, activeDivisions, activeConferences, activePlayerTeams, currTeams, currCities, currStates, currDivisions, currConferences, currPlayerTeams))
+        playerHeuristics.append(calculatePlayerHeuristic(activePlayers, activePoints, activePositions, activePlayerTeams, currPlayers, currPoints, currPositions, currPlayerTeams))
+        usageHeuristics.append(calculateUsageHeuristic(activeFavoriteRatio, activeUserTotalInteractionsRatio, currFavoriteRatio, currUserTotalInteractionsRatio))
+        interactionHeuristics.append(calculateInteractionHeuristic(activeUserInteractions, currUserInteractions))
     
-    data = resp.data
-    userCounts = {}
-    for favorite in data:
-        userCounts[favorite["user_id"]] = userCounts[favorite["user_id"]] + 1 if favorite["user_id"] in userCounts else 1
+    # normalizing all the heuristic values for each user
+    normalizedTeamHeuristics = normalizeArrayData(teamHeuristics)
+    normalizedPlayerHeuristics = normalizeArrayData(playerHeuristics)
+    normalizedUsageHeuristics = normalizeArrayData(usageHeuristics)
+    normalizedInteractionHeuristics = normalizeArrayData(interactionHeuristics)
+
+    # adding up each user's heuristic values
+    totalHeuristicWeights = []
+    for i in range(len(teamHeuristics)):
+        totalHeuristicWeights.append(normalizedTeamHeuristics[i] + normalizedPlayerHeuristics[i] + normalizedUsageHeuristics[i] + normalizedInteractionHeuristics[i])
     
-    return sum(userCounts.values()) / userCount
-
-# get all the information that I need from favorited players
-def getFavoritePlayerInfo(players):
-    playerPositions = set()
-    playerTeams = set()
-    playerPoints = set()
-
-    df = getPlayerSeasonStats()
-
-    for player_id in players:
-        matched = df[df["PLAYER_ID"] == player_id].iloc[0]
-        additionalInfo = additionalPlayerInfo(player_id)
-        playerData = playerJson(matched, player_id, additionalInfo)
-
-        playerPositions.add(playerData["position"])
-        playerTeams.add(playerData["team"])
-        playerPoints.add(playerData["pts"].item())
+    # creating a dictionary that matches user id to total heuristic value
+    matched = {}
+    foundActiveUser = 0
+    for i in range(len(users)):
+        if users[i] == activeUser:
+            foundActiveUser = 1
+            continue
+        
+        matched[users[i]] = totalHeuristicWeights[i - foundActiveUser]
     
-    return [playerPositions, playerTeams, playerPoints]
-
-# get all the information that I need from favorited teams
-def getFavoriteTeamInfo(teams):
-    sb = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
-
-    teamCities = set()
-    teamStates = set()
-    teamDivisions = set()
-    teamConferences = set()
-
-    for team_id in teams:
-        team = sb.from_("nba_teams")\
-            .select("city,state,division,conference")\
-            .eq("id", team_id)\
-            .execute()
-        team = team.data[0]
-
-        teamCities.add(team["city"])
-        teamStates.add(team["state"])
-        teamDivisions.add(team["division"])
-        teamConferences.add(team["conference"])
+    topSimilar = sorted(matched.items(), key=lambda kv: kv[1], reverse=True)[:5] # getting top 5 similar but can change this value
     
-    return [teamCities, teamStates, teamDivisions, teamConferences]
+    # adding the total weights for each similar user
+    similarWeights = []
+    for user in topSimilar:
+        userInteractions = getUserInteractions(sb, interactionAverages, user[0])
+        userWeights = getUserWeights(user[0], userInteractions)
+        similarWeights = [a + b for a, b in zip(similarWeights, userWeights)] if len(similarWeights) > 0 else userWeights
+    
+    return [num / len(topSimilar) * 0.5 for num in similarWeights] # returning the average of all similar weights * 0.5 (0.5 because we want similar weights to hold 50% weight for final user weight)
 
-# getting the id for all users
-def getUsers():
-    sb = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
-    resp = sb.from_("profiles")\
-        .select("id")\
-        .execute()
-    
-    userIds = []
-    for user in resp.data:
-        userIds.append(user["id"])
-    
-    return userIds
+# get all the values that I need for both active users and non-active users
+def getUserValues(user, sb, interactionAverages, favoriteAverage):
+    players, teams = getActiveUserFavorites(user)
+    cities, states, divisions, conferences = getFavoriteTeamInfo(teams)
+    positions, playerTeams, points = getFavoritePlayerInfo(players)
+    favoriteRatio = (len(players) + len(teams)) / favoriteAverage
+    userInteractions = getUserInteractions(sb, interactionAverages, user)
+    userTotalInteractionsRatio = sum(userInteractions.values()) / sum(interactionAverages.values())
+
+    return [players, teams, cities, states, divisions, conferences, positions, playerTeams, points, favoriteRatio, userInteractions, userTotalInteractionsRatio]
 
 # calculating the points value for similar favorite teams
 def calculateTeamHeuristic(activeTeams, activeCities, activeStates, activeDivisions, activeConferences, activePlayerTeams, currTeams, currCities, currStates, currDivisions, currConferences, currPlayerTeams):
@@ -102,6 +83,11 @@ def calculateTeamHeuristic(activeTeams, activeCities, activeStates, activeDivisi
         return ONE_SIMILAR
     
     # everything from here on becomes more generalized so we want to return the value associated with the most specific relationship
+    # each conference has 3 divisions, in each division are 5 teams
+    # teams in the same city are in the same division
+    # teams that are in the same state are also in the same division
+    # basically if a team is in the same city, they are by automatically a part of the same state, division, and conference
+    # same logic applies for any level moving outwards
     similarPlayerTeams = activePlayerTeams & currPlayerTeams
     if len(similarPlayerTeams) > 1:
         return MULTIPLE_SIMILAR_PLAYER_TEAMS[0]
@@ -128,10 +114,10 @@ def calculateTeamHeuristic(activeTeams, activeCities, activeStates, activeDivisi
 
 # calculating the points value for similar favorite players
 def calculatePlayerHeuristic(activePlayers, activePoints, activePositions, activePlayerTeams, currPlayers, currPoints, currPositions, currPlayerTeams):
-    similarTeams = activePlayers & currPlayers
-    if len(similarTeams) > 1:
+    similarPlayers = activePlayers & currPlayers
+    if len(similarPlayers) > 1:
         return MULTIPLE_SIMILAR
-    elif len(similarTeams) == 1:
+    elif len(similarPlayers) == 1:
         return ONE_SIMILAR
     
     # points are more general than the following so we don't want to worry about anything else if this is similar between players
@@ -233,67 +219,90 @@ def normalizeArrayData(data):
     normalizedData = (numpyData - mean) / stdDev
     return normalizedData.tolist()
 
-# get all the values that I need for both active users and non-active users
-def getUserValues(user, sb, interactionAverages, favoriteAverage):
-    players, teams = getActiveUserFavorites(user)
-    cities, states, divisions, conferences = getFavoriteTeamInfo(teams)
-    positions, playerTeams, points = getFavoritePlayerInfo(players)
-    favoriteRatio = (len(players) + len(teams)) / favoriteAverage
-    userInteractions = getUserInteractions(sb, interactionAverages, user)
-    userTotalInteractionsRatio = sum(userInteractions.values()) / sum(interactionAverages.values())
+# get all the favorites for a given user
+def getActiveUserFavorites(user_id):
+    sb = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+    resp = sb.from_("favorites")\
+        .select("target_id, target_type")\
+        .eq("user_id", user_id)\
+        .execute()
+    favorites = resp.data
 
-    return [players, teams, cities, states, divisions, conferences, positions, playerTeams, points, favoriteRatio, userInteractions, userTotalInteractionsRatio]
-
-# combining all the functions that I have to determine the values for weights based on similar user groups
-def getSimilarUserWeights(sb, activeUser, users, favoriteCountAverage, interactionAverages):
-    # getting necessary variables for the user that is currently logged in
-    activePlayers, activeTeams, activeCities, activeStates, activeDivisions, activeConferences, activePositions, activePlayerTeams, activePoints, activeFavoriteRatio, activeUserInteractions, activeUserTotalInteractionsRatio = getUserValues(activeUser, sb, interactionAverages, favoriteCountAverage)
-
-    teamHeuristics = []
-    playerHeuristics = []
-    usageHeuristics = []
-    interactionHeuristics = []
-    for currUser in users:
-        if currUser == activeUser:
-            continue
+    players = set()
+    teams = set()
+    for favorite in favorites:
+        if favorite["target_type"] == "player":
+            players.add(favorite["target_id"])
+        else:
+            teams.add(favorite["target_id"])
         
-        # getting necessary variables for all users that are not the currently logged in user
-        currPlayers, currTeams, currCities, currStates, currDivisions, currConferences, currPositions, currPlayerTeams, currPoints, currFavoriteRatio, currUserInteractions, currUserTotalInteractionsRatio = getUserValues(currUser, sb, interactionAverages, favoriteCountAverage)
+    return [players, teams]
 
-        # calculating heuristic values for each user
-        teamHeuristics.append(calculateTeamHeuristic(activeTeams, activeCities, activeStates, activeDivisions, activeConferences, activePlayerTeams, currTeams, currCities, currStates, currDivisions, currConferences, currPlayerTeams))
-        playerHeuristics.append(calculatePlayerHeuristic(activePlayers, activePoints, activePositions, activePlayerTeams, currPlayers, currPoints, currPositions, currPlayerTeams))
-        usageHeuristics.append(calculateUsageHeuristic(activeFavoriteRatio, activeUserTotalInteractionsRatio, currFavoriteRatio, currUserTotalInteractionsRatio))
-        interactionHeuristics.append(calculateInteractionHeuristic(activeUserInteractions, currUserInteractions))
+# get the average favorite count across all users
+def getFavoriteCountAverage(userCount):
+    sb = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+    resp = sb.from_("favorites")\
+        .select("user_id")\
+        .execute()
     
-    # normalizing all the heuristic values for each user
-    normalizedTeamHeuristics = normalizeArrayData(teamHeuristics)
-    normalizedPlayerHeuristics = normalizeArrayData(playerHeuristics)
-    normalizedUsageHeuristics = normalizeArrayData(usageHeuristics)
-    normalizedInteractionHeuristics = normalizeArrayData(interactionHeuristics)
+    data = resp.data
+    userCounts = {}
+    for favorite in data:
+        userCounts[favorite["user_id"]] = userCounts[favorite["user_id"]] + 1 if favorite["user_id"] in userCounts else 1
+    
+    return sum(userCounts.values()) / userCount
 
-    # adding up each user's heuristic values
-    totalHeuristicWeights = []
-    for i in range(len(teamHeuristics)):
-        totalHeuristicWeights.append(normalizedTeamHeuristics[i] + normalizedPlayerHeuristics[i] + normalizedUsageHeuristics[i] + normalizedInteractionHeuristics[i])
+# get all the information that I need from favorited players
+def getFavoritePlayerInfo(players):
+    playerPositions = set()
+    playerTeams = set()
+    playerPoints = set()
+
+    df = getPlayerSeasonStats()
+
+    for player_id in players:
+        matched = df[df["PLAYER_ID"] == player_id].iloc[0]
+        additionalInfo = additionalPlayerInfo(player_id)
+        playerData = playerJson(matched, player_id, additionalInfo)
+
+        playerPositions.add(playerData["position"])
+        playerTeams.add(playerData["team"])
+        playerPoints.add(playerData["pts"].item())
     
-    # creating a dictionary that matches user id to total heuristic value
-    matched = {}
-    foundActiveUser = 0
-    for i in range(len(users)):
-        if users[i] == activeUser:
-            foundActiveUser = 1
-            continue
-        
-        matched[users[i]] = totalHeuristicWeights[i - foundActiveUser]
+    return [playerPositions, playerTeams, playerPoints]
+
+# get all the information that I need from favorited teams
+def getFavoriteTeamInfo(teams):
+    sb = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+
+    teamCities = set()
+    teamStates = set()
+    teamDivisions = set()
+    teamConferences = set()
+
+    for team_id in teams:
+        team = sb.from_("nba_teams")\
+            .select("city,state,division,conference")\
+            .eq("id", team_id)\
+            .execute()
+        team = team.data[0]
+
+        teamCities.add(team["city"])
+        teamStates.add(team["state"])
+        teamDivisions.add(team["division"])
+        teamConferences.add(team["conference"])
     
-    topSimilar = sorted(matched.items(), key=lambda kv: kv[1], reverse=True)[:5] # getting top 5 similar but can change this value
+    return [teamCities, teamStates, teamDivisions, teamConferences]
+
+# getting the id for all users
+def getUsers():
+    sb = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+    resp = sb.from_("profiles")\
+        .select("id")\
+        .execute()
     
-    # adding the total weights for each similar user
-    similarWeights = []
-    for user in topSimilar:
-        userInteractions = getUserInteractions(sb, interactionAverages, user[0])
-        userWeights = getUserWeights(user[0], userInteractions)
-        similarWeights = [a + b for a, b in zip(similarWeights, userWeights)] if len(similarWeights) > 0 else userWeights
+    userIds = []
+    for user in resp.data:
+        userIds.append(user["id"])
     
-    return [num / len(topSimilar) * 0.5 for num in similarWeights] # returning the average of all similar weights * 0.5 (0.5 because we want similar weights to hold 50% weight for final user weight)
+    return userIds

--- a/backend/similarUserWeights.py
+++ b/backend/similarUserWeights.py
@@ -1,0 +1,299 @@
+from configuration import SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY, MULTIPLE_SIMILAR, ONE_SIMILAR, MULTIPLE_SIMILAR_PLAYER_TEAMS, ONE_SIMILAR_PLAYER_TEAM, SAME_CITY, SAME_STATE, SAME_DIVISION, SAME_CONFERENCE, SIMILAR_PPG, SIMILAR_POSITION, SIMILAR_INTERACTION, NEIGHBORING_INTERACTION
+from predictionDataHelpers import getInteractionAverages, getUserInteractions, getUserWeights
+from stats import additionalPlayerInfo, getPlayerSeasonStats
+from modalHelpers import playerJson
+from supabase import create_client
+import numpy as np
+
+# get all the favorites for a given user
+def getActiveUserFavorites(user_id):
+    sb = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+    resp = sb.from_("favorites")\
+        .select("target_id, target_type")\
+        .eq("user_id", user_id)\
+        .execute()
+    favorites = resp.data
+
+    players = set()
+    teams = set()
+    for favorite in favorites:
+        if favorite["target_type"] == "player":
+            players.add(favorite["target_id"])
+        else:
+            teams.add(favorite["target_id"])
+        
+    return [players, teams]
+
+# get the average favorite count across all users
+def getFavoriteCountAverage(userCount):
+    sb = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+    resp = sb.from_("favorites")\
+        .select("user_id")\
+        .execute()
+    
+    data = resp.data
+    userCounts = {}
+    for favorite in data:
+        userCounts[favorite["user_id"]] = userCounts[favorite["user_id"]] + 1 if favorite["user_id"] in userCounts else 1
+    
+    return sum(userCounts.values()) / userCount
+
+# get all the information that I need from favorited players
+def getFavoritePlayerInfo(players):
+    playerPositions = set()
+    playerTeams = set()
+    playerPoints = set()
+
+    df = getPlayerSeasonStats()
+
+    for player_id in players:
+        matched = df[df["PLAYER_ID"] == player_id].iloc[0]
+        additionalInfo = additionalPlayerInfo(player_id)
+        playerData = playerJson(matched, player_id, additionalInfo)
+
+        playerPositions.add(playerData["position"])
+        playerTeams.add(playerData["team"])
+        playerPoints.add(playerData["pts"].item())
+    
+    return [playerPositions, playerTeams, playerPoints]
+
+# get all the information that I need from favorited teams
+def getFavoriteTeamInfo(teams):
+    sb = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+
+    teamCities = set()
+    teamStates = set()
+    teamDivisions = set()
+    teamConferences = set()
+
+    for team_id in teams:
+        team = sb.from_("nba_teams")\
+            .select("city,state,division,conference")\
+            .eq("id", team_id)\
+            .execute()
+        team = team.data[0]
+
+        teamCities.add(team["city"])
+        teamStates.add(team["state"])
+        teamDivisions.add(team["division"])
+        teamConferences.add(team["conference"])
+    
+    return [teamCities, teamStates, teamDivisions, teamConferences]
+
+# getting the id for all users
+def getUsers():
+    sb = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+    resp = sb.from_("profiles")\
+        .select("id")\
+        .execute()
+    
+    userIds = []
+    for user in resp.data:
+        userIds.append(user["id"])
+    
+    return userIds
+
+# calculating the points value for similar favorite teams
+def calculateTeamHeuristic(activeTeams, activeCities, activeStates, activeDivisions, activeConferences, activePlayerTeams, currTeams, currCities, currStates, currDivisions, currConferences, currPlayerTeams):
+    similarTeams = activeTeams & currTeams
+    if len(similarTeams) > 1:
+        return MULTIPLE_SIMILAR
+    elif len(similarTeams) == 1:
+        return ONE_SIMILAR
+    
+    # everything from here on becomes more generalized so we want to return the value associated with the most specific relationship
+    similarPlayerTeams = activePlayerTeams & currPlayerTeams
+    if len(similarPlayerTeams) > 1:
+        return MULTIPLE_SIMILAR_PLAYER_TEAMS[0]
+    elif len(similarPlayerTeams) == 1:
+        return ONE_SIMILAR_PLAYER_TEAM[0]
+    
+    similarCities = activeCities & currCities
+    if len(similarCities) >= 1:
+        return SAME_CITY
+    
+    similarStates = activeStates & currStates
+    if len(similarStates) >= 1:
+        return SAME_STATE
+
+    similarDivisions = activeDivisions & currDivisions
+    if len(similarDivisions) >= 1:
+        return SAME_DIVISION
+    
+    similarConferences = activeConferences & currConferences
+    if len(similarConferences) >= 1:
+        return SAME_CONFERENCE
+    
+    return 0
+
+# calculating the points value for similar favorite players
+def calculatePlayerHeuristic(activePlayers, activePoints, activePositions, activePlayerTeams, currPlayers, currPoints, currPositions, currPlayerTeams):
+    similarTeams = activePlayers & currPlayers
+    if len(similarTeams) > 1:
+        return MULTIPLE_SIMILAR
+    elif len(similarTeams) == 1:
+        return ONE_SIMILAR
+    
+    # points are more general than the following so we don't want to worry about anything else if this is similar between players
+    for point in currPoints:
+        for average in activePoints:
+            if abs(average - point) <= 3:
+                return SIMILAR_PPG
+    
+    # position is more indicative of similarity than same team so if this holds we don't want to continue
+    similarPositions = activePositions & currPositions
+    if len(similarPositions) == 1:
+        return SIMILAR_POSITION
+    
+    similarPlayerTeams = activePlayerTeams & currPlayerTeams
+    if len(similarPlayerTeams) > 1:
+        return MULTIPLE_SIMILAR_PLAYER_TEAMS[1]
+    elif len(similarPlayerTeams) == 1:
+        return ONE_SIMILAR_PLAYER_TEAM[1]
+    
+# calculating the points value based on similar usages (interaction and favorite counts)
+def calculateUsageHeuristic(activeFavoriteRatio, activeUserTotalInteractionsRatio, currFavoriteRatio, currUserTotalInteractionsRatio):
+    # calculating the ratio category for active user and non-active user for both favorite and interaction total
+    if activeFavoriteRatio > 1.25:
+        activeFavoriteCategory = "high"
+    elif activeFavoriteRatio < 0.75:
+        activeFavoriteCategory = "low"
+    else:
+        activeFavoriteCategory = "average"
+
+    if currFavoriteRatio > 1.25:
+        currFavoriteCategory = "high"
+    elif currFavoriteRatio < 0.75:
+        currFavoriteCategory = "low"
+    else:
+        currFavoriteCategory = "average"
+
+    if activeUserTotalInteractionsRatio > 1.25:
+        activeUserTotalInteractionCategory = "high"
+    elif activeUserTotalInteractionsRatio < 0.75:
+        activeUserTotalInteractionCategory = "low"
+    else:
+        activeUserTotalInteractionCategory = "average"
+
+    if currUserTotalInteractionsRatio > 1.25:
+        currUserTotalInteractionCategory = "high"
+    elif currUserTotalInteractionsRatio < 0.75:
+        currUserTotalInteractionCategory = "low"
+    else:
+        currUserTotalInteractionCategory = "average"
+
+    # determining total points based on similarity or neighboring categories for both favorite and total interaction
+    points = 0
+    if activeFavoriteCategory == currFavoriteCategory:
+        points += SIMILAR_INTERACTION[0]
+    elif activeFavoriteCategory == "average" or currFavoriteCategory == "average":
+        points += NEIGHBORING_INTERACTION[0]
+    if activeUserTotalInteractionCategory == currUserTotalInteractionCategory:
+        points += SIMILAR_INTERACTION[0]
+    elif activeUserTotalInteractionCategory == "average" or currUserTotalInteractionCategory == "average":
+        points += NEIGHBORING_INTERACTION[0]
+    
+    return points
+
+# calculating the points value based on similar per-interaction usages
+def calculateInteractionHeuristic(activeUserInteractions, currUserInteractions):
+    points = 0
+    # getting total interaction points based on similar or neighboring category for each interaction type
+    for category in activeUserInteractions:
+        if activeUserInteractions[category] > 1.25:
+            activeUserInteractionsCategory = "high"
+        elif activeUserInteractions[category] < 0.75:
+            activeUserInteractionsCategory = "low"
+        else:
+            activeUserInteractionsCategory = "average"
+
+        if currUserInteractions[category] > 1.25:
+            currUserInteractionsCategory = "high"
+        elif currUserInteractions[category] < 0.75:
+            currUserInteractionsCategory = "low"
+        else:
+            currUserInteractionsCategory = "average"
+
+        if activeUserInteractionsCategory == currUserInteractionsCategory:
+            points += SIMILAR_INTERACTION[1]
+        elif activeUserInteractionsCategory == "average" or currUserInteractionsCategory == "average":
+            points += NEIGHBORING_INTERACTION[1]
+
+    return points
+
+# normalize a given array of data
+def normalizeArrayData(data):
+    numpyData = np.array(data)
+    mean = numpyData.mean()
+    stdDev = numpyData.std(ddof=0)
+
+    if not stdDev:
+        return [0 for point in data]
+    
+    normalizedData = (numpyData - mean) / stdDev
+    return normalizedData.tolist()
+
+# get all the values that I need for both active users and non-active users
+def getUserValues(user, sb, interactionAverages, favoriteAverage):
+    players, teams = getActiveUserFavorites(user)
+    cities, states, divisions, conferences = getFavoriteTeamInfo(teams)
+    positions, playerTeams, points = getFavoritePlayerInfo(players)
+    favoriteRatio = (len(players) + len(teams)) / favoriteAverage
+    userInteractions = getUserInteractions(sb, interactionAverages, user)
+    userTotalInteractionsRatio = sum(userInteractions.values()) / sum(interactionAverages.values())
+
+    return [players, teams, cities, states, divisions, conferences, positions, playerTeams, points, favoriteRatio, userInteractions, userTotalInteractionsRatio]
+
+# combining all the functions that I have to determine the values for weights based on similar user groups
+def getSimilarUserWeights(sb, activeUser, users, favoriteCountAverage, interactionAverages):
+    # getting necessary variables for the user that is currently logged in
+    activePlayers, activeTeams, activeCities, activeStates, activeDivisions, activeConferences, activePositions, activePlayerTeams, activePoints, activeFavoriteRatio, activeUserInteractions, activeUserTotalInteractionsRatio = getUserValues(activeUser, sb, interactionAverages, favoriteCountAverage)
+
+    teamHeuristics = []
+    playerHeuristics = []
+    usageHeuristics = []
+    interactionHeuristics = []
+    for currUser in users:
+        if currUser == activeUser:
+            continue
+        
+        # getting necessary variables for all users that are not the currently logged in user
+        currPlayers, currTeams, currCities, currStates, currDivisions, currConferences, currPositions, currPlayerTeams, currPoints, currFavoriteRatio, currUserInteractions, currUserTotalInteractionsRatio = getUserValues(currUser, sb, interactionAverages, favoriteCountAverage)
+
+        # calculating heuristic values for each user
+        teamHeuristics.append(calculateTeamHeuristic(activeTeams, activeCities, activeStates, activeDivisions, activeConferences, activePlayerTeams, currTeams, currCities, currStates, currDivisions, currConferences, currPlayerTeams))
+        playerHeuristics.append(calculatePlayerHeuristic(activePlayers, activePoints, activePositions, activePlayerTeams, currPlayers, currPoints, currPositions, currPlayerTeams))
+        usageHeuristics.append(calculateUsageHeuristic(activeFavoriteRatio, activeUserTotalInteractionsRatio, currFavoriteRatio, currUserTotalInteractionsRatio))
+        interactionHeuristics.append(calculateInteractionHeuristic(activeUserInteractions, currUserInteractions))
+    
+    # normalizing all the heuristic values for each user
+    normalizedTeamHeuristics = normalizeArrayData(teamHeuristics)
+    normalizedPlayerHeuristics = normalizeArrayData(playerHeuristics)
+    normalizedUsageHeuristics = normalizeArrayData(usageHeuristics)
+    normalizedInteractionHeuristics = normalizeArrayData(interactionHeuristics)
+
+    # adding up each user's heuristic values
+    totalHeuristicWeights = []
+    for i in range(len(teamHeuristics)):
+        totalHeuristicWeights.append(normalizedTeamHeuristics[i] + normalizedPlayerHeuristics[i] + normalizedUsageHeuristics[i] + normalizedInteractionHeuristics[i])
+    
+    # creating a dictionary that matches user id to total heuristic value
+    matched = {}
+    foundActiveUser = 0
+    for i in range(len(users)):
+        if users[i] == activeUser:
+            foundActiveUser = 1
+            continue
+        
+        matched[users[i]] = totalHeuristicWeights[i - foundActiveUser]
+    
+    topSimilar = sorted(matched.items(), key=lambda kv: kv[1], reverse=True)[:5] # getting top 5 similar but can change this value
+    
+    # adding the total weights for each similar user
+    similarWeights = []
+    for user in topSimilar:
+        userInteractions = getUserInteractions(sb, interactionAverages, user[0])
+        userWeights = getUserWeights(user[0], userInteractions)
+        similarWeights = [a + b for a, b in zip(similarWeights, userWeights)] if len(similarWeights) > 0 else userWeights
+    
+    return [num / len(topSimilar) * 0.5 for num in similarWeights] # returning the average of all similar weights * 0.5 (0.5 because we want similar weights to hold 50% weight for final user weight)

--- a/backend/stats.py
+++ b/backend/stats.py
@@ -1,5 +1,7 @@
-from nba_api.stats.endpoints import commonplayerinfo, leaguedashplayerstats, leaguedashteamstats, playergamelog, teamgamelog, commonteamroster
+from nba_api.stats.endpoints import commonplayerinfo, teaminfocommon, leaguedashplayerstats, leaguedashteamstats, playergamelog, teamgamelog
 from nba_api.stats.static import teams
+from supabase import create_client
+from configuration import SUPABASE_URL, SUPABASE_ANON_KEY
 from functools import lru_cache
 
 currSeason = '2024-25'
@@ -80,3 +82,38 @@ def additionalPlayerInfo(player_id):
         "height":   height_formatted,
         "weight":   info_df["WEIGHT"].iat[0],
     }
+
+# * UNCOMMENT THIS TO UPDATE NBA TEAM CHARACTERISTICS
+# def loadNbaTeams():
+#     sb = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+
+#     teamData = teams.get_teams()
+#     for team in teamData[28:]:
+#         id = team["id"]
+#         city = team["city"]
+#         state = team["state"]
+
+#         additionalData = teaminfocommon.TeamInfoCommon(
+#             team_id=id, 
+#             league_id="00").get_data_frames()[0]
+#         print(additionalData)
+#         division   = additionalData["TEAM_DIVISION"].iloc[0]
+#         conference = additionalData["TEAM_CONFERENCE"].iloc[0]
+#         abbreviation       = additionalData["TEAM_ABBREVIATION"].iloc[0]
+
+#         sb.from_("nba_teams")\
+#             .upsert({
+#                 "id": id,
+#                 "abbreviation": abbreviation,
+#                 "city": city,
+#                 "state": state,
+#                 "division": division,
+#                 "conference": conference
+#                 }, on_conflict="id")\
+#             .execute()
+
+# def main():
+#     loadNbaTeams()
+
+# if __name__ == "__main__":
+#     main()

--- a/frontend/src/components/PlayerModal.jsx
+++ b/frontend/src/components/PlayerModal.jsx
@@ -6,6 +6,7 @@ import { UserAuth } from "../context/AuthContext"
 import { getGameData, getPointsPrediction, updateInteractionCounts} from "../utils/api"
 import { Tooltip } from "./Tooltip"
 import { filterRecency, createGraph, centerWeek, isWeekRange } from "../utils/chart";
+import { Loader } from "./Loader";
 
 const MOUSE_OFFSET = 510 // 520 is the distance of error from the mouse and the points
 const DRAG_THRESHOLD = 30 // we want drags to be somewhat significant
@@ -19,6 +20,8 @@ export function PlayerModal({ onClose, data, isFav, toggleFav }) {
     // this makes it easier on the user to not have to hover on each individual point
     const [mouseXPosition, setMouseXPosition] = useState(null);
     const hoveredPointRef = useRef({});
+
+    const [loading, setLoading] = useState(false);
 
     const [graphOption, setGraphOption] = useState("points");
     const [playerStats, setPlayerStats] = useState([]);
@@ -105,8 +108,11 @@ export function PlayerModal({ onClose, data, isFav, toggleFav }) {
     }
 
     const getPredictedPoints = async () => { 
+        setLoading(true)
         const points = await getPointsPrediction(session, features);
         setPredictedPoints(points);
+        setLoading(false);
+        updateInteractionCounts("point", session);
     }
 
     const handleMouseMove = (e) => {
@@ -293,6 +299,7 @@ export function PlayerModal({ onClose, data, isFav, toggleFav }) {
                         </span>
                     </div>}
                 </div>
+                {loading && <Loader/>}
             </div>
         </div>
     )


### PR DESCRIPTION
## Description
In this PR, I changed up how I calculate the weights used for the prediction model. I added a way to also take into consideration the weights of users that are similar to the active user. The final weight is calculated by taking the sum of half the active user weight and half of the similar user weight. 

The criteria for determining similar users and my method of implementation can be found [here](https://docs.google.com/document/d/1yAKIS0nE7ugtMy7yZ_GgixvvHZDKk_DCaWhd5Jz3fFs/edit?usp=sharing)

Future PR's will either consist of me continuing to iterate over TC2, doing E2E testing, or both.
